### PR TITLE
Feature Request: Building on Mac/Linux using Makefiles/arm-gcc

### DIFF
--- a/Device/device.mk
+++ b/Device/device.mk
@@ -1,0 +1,5 @@
+DEVICE_SRC = 	Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c \
+				Device/stm32f3xx_hal_msp.c \
+				Device/stm32f3xx_it.c \
+
+STARTUPASM =	CubeMX/startup/startup_stm32f303xc.s

--- a/Drivers/drivers.mk
+++ b/Drivers/drivers.mk
@@ -1,0 +1,52 @@
+HWDRIVER_SRC =  Drivers/HWDrivers/Src/driverHWADC.c \
+			    Drivers/HWDrivers/Src/driverHWEEPROM.c \
+			    Drivers/HWDrivers/Src/driverHWI2C1.c \
+			    Drivers/HWDrivers/Src/driverHWI2C2.c \
+			    Drivers/HWDrivers/Src/driverHWPowerState.c \
+			    Drivers/HWDrivers/Src/driverHWSPI1.c \
+			    Drivers/HWDrivers/Src/driverHWStatus.c \
+			    Drivers/HWDrivers/Src/driverHWSwitches.c \
+			    Drivers/HWDrivers/Src/driverHWUART2.c \
+
+HWDRIVER_INC =	Drivers/HWDrivers/Inc
+
+SWDRIVER_SRC =	Drivers/SWDrivers/Src/driverSWADC128D818.c \
+				Drivers/SWDrivers/Src/driverSWCC1101.c \
+				Drivers/SWDrivers/Src/driverSWDCDC.c \
+				Drivers/SWDrivers/Src/driverSWEMC2305.c \
+				Drivers/SWDrivers/Src/driverSWISL28022.c \
+				Drivers/SWDrivers/Src/driverSWLTC6803.c \
+				Drivers/SWDrivers/Src/driverSWLTC6804.c \
+				Drivers/SWDrivers/Src/driverSWPCAL6416.c \
+				Drivers/SWDrivers/Src/driverSWSHT21.c \
+				Drivers/SWDrivers/Src/driverSWSSD1306.c \
+				Drivers/SWDrivers/Src/driverSWStorageManager.c \
+				Drivers/SWDrivers/Src/driverSWUART2.c \
+
+SWDRIVER_INC =	Drivers/SWDrivers/Inc
+
+HAL_SRC =	Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_pwr_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_cortex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_uart.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_uart_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_can.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_adc_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_tim_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_pwr.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_spi.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_i2c.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_spi_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_i2c_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_rcc_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_flash_ex.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_rcc.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_tim.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_flash.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_adc.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_gpio.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_dma.c \
+			Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_iwdg.c \
+
+HAL_INC = 		Drivers/STM32F3xx_HAL_Driver/Inc \
+				Drivers/CMSIS/Include/

--- a/Libraries/lib.mk
+++ b/Libraries/lib.mk
@@ -1,0 +1,9 @@
+LIB_SRC = 	Libraries/Scr/libBuffer.c \
+			Libraries/Scr/libCRC.c \
+			Libraries/Scr/libGLCDFont.c \
+			Libraries/Scr/libGraphics.c \
+			Libraries/Scr/libLogos.c \
+			Libraries/Scr/libPacket.c \
+			Libraries/Scr/libRingbuffer.c \
+
+LIB_INC = 	Libraries/Inc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+# Subdirectory make stuff
+
+include Libraries/lib.mk
+include Modules/modules.mk 
+include Device/device.mk
+include Drivers/drivers.mk
+
+# Compiler stuff
+TRGT = arm-none-eabi-
+CC   = $(TRGT)gcc
+CPPC = $(TRGT)g++
+# Enable loading with g++ only if you need C++ runtime support.
+# NOTE: You can use C++ even without C++ support if you are careful. C++
+#       runtime support makes code size explode.
+LD   = $(TRGT)gcc
+#LD   = $(TRGT)g++
+CP   = $(TRGT)objcopy
+AS   = $(TRGT)gcc -x assembler-with-cpp
+AR   = $(TRGT)ar
+OD   = $(TRGT)objdump
+SZ   = $(TRGT)size
+HEX  = $(CP) -O ihex
+BIN  = $(CP) -O binary
+
+# Define C warning options here
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes -Wshadow
+# Define extra C flags here
+
+CFLAGS = -T $(LDSCRIPT) -mthumb -mcpu=$(MCU) -D STM32F303xC -D USE_HAL_DRIVER
+
+# Architecture specific stuff - linker script and architecture
+LDSCRIPT= CubeMX/STM32F303CC_FLASH.ld
+MCU  = cortex-m4
+
+ASMSRC = $(STARTUPASM)
+
+CSRC := 	$(DEVICE_SRC) \
+		$(LIB_SRC) \
+		$(MOD_SRC) \
+		$(HWDRIVER_SRC) \
+		$(SWDRIVER_SRC) \
+		$(HAL_SRC) \
+		Main/main.c
+
+INCDIR = Main \
+		$(LIB_INC) \
+		$(MOD_INC) \
+		$(HWDRIVER_INC) \
+		$(SWDRIVER_INC) \
+		$(HAL_INC) \
+		CubeMX/Drivers/CMSIS/Device/ST/STM32F3xx/Include
+
+IINCDIR   = $(patsubst %,-I%,$(INCDIR))
+
+all: DieBieBMS-firmware.bin DieBieBMS-firmware.elf
+
+DieBieBMS-firmware.bin: DieBieBMS-firmware.elf
+	$(BIN) DieBieBMS-firmware.elf DieBieBMS-firmware.bin --gap-fill 0xFF
+
+DieBieBMS-firmware.elf: $(CSRC)
+	$(CC) $(CWARN) $(CFLAGS) $(ASMSRC) $(CSRC) $(IINCDIR) --specs=nosys.specs -o $@

--- a/Modules/modules.mk
+++ b/Modules/modules.mk
@@ -1,0 +1,16 @@
+MOD_SRC =	Modules/Src/modCAN.c \
+			Modules/Src/modCommands.c \
+			Modules/Src/modConfig.c \
+			Modules/Src/modDelay.c \
+			Modules/Src/modDisplay.c \
+			Modules/Src/modEffect.c \
+			Modules/Src/modFlash.c \
+			Modules/Src/modHiAmp.c \
+			Modules/Src/modOperationalState.c \
+			Modules/Src/modPowerElectronics.c \
+			Modules/Src/modPowerState.c \
+			Modules/Src/modStateOfCharge.c \
+			Modules/Src/modTerminal.c \
+			Modules/Src/modUART.c \
+
+MOD_INC =	Modules/Inc


### PR DESCRIPTION
**Motivation:**
It's nice to be able to build the firmware on something that isn't Keil uVision - we won't need to pay for the license, the bin size is not limited by the license, we can use open source tools to flash and debug the firmware, and we can test in-house and build on the cloud. 

**Change list:**
- Makefiles to be able to build using just arm-none-eabi-gcc. 

**Testing:**
TBD - in the process of setting up my bench development setup
